### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,18 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 
-## [1.0.1] (2025-10-07)
+## [1.1.0] (2026-06-05)
+
+### Added
+
+- `externalId` and `externalLabel` fields in the authorized user response
+
+### Changed
+
+- Make `firstName`, `lastName`, and `email` optional in the authorized user response
+- Read OpenID claims (`given_name`, `family_name`, `email`) defensively to avoid crashes when a claim is missing
+
+## [1.0.2] (2025-10-07)
 
 ### Fixed
 
@@ -30,4 +41,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
 [Unreleased]: /../../compare/main...develop
+[1.1.0]: /../../compare/v1.0.2...v1.1.0
+[1.0.2]: /../../compare/v1.0.1...v1.0.2
+[1.0.1]: /../../compare/v1.0.0...v1.0.1
 [1.0.0]: /../../tree/v1.0.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.abspath('../src'))
 project = 'FAIR Wizard Integration SDK'
 copyright = '2024, Codevence Solutions'
 author = 'Codevence Solutions'
-release = '0.1.0'
+release = '1.1.0'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'fair-wizard-integration-sdk'
-version = '1.0.2'
+version = '1.1.0'
 description = 'Python SDK for building integrations with FAIR Wizard'
 readme = 'README.md'
 keywords = ['fair-wizard', 'integration', 'automation', 'sdk']


### PR DESCRIPTION
Bump version to 1.1.0, add externalId/externalLabel changelog entry, and correct the 1.0.1/1.0.2 history and comparison links.