### PR TITLE
Release 1.1.1 (develop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
 
+## [1.1.1] (2026-06-05)
+
+### Fixed
+
+- Pin `pydantic` and `pydantic_core` versions when building the Lambda layer to avoid a runtime version mismatch
+
 ## [1.1.0] (2026-06-05)
 
 ### Added
@@ -41,6 +47,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
 [Unreleased]: /../../compare/main...develop
+[1.1.1]: /../../compare/v1.1.0...v1.1.1
 [1.1.0]: /../../compare/v1.0.2...v1.1.0
 [1.0.2]: /../../compare/v1.0.1...v1.0.2
 [1.0.1]: /../../compare/v1.0.0...v1.0.1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.abspath('../src'))
 project = 'FAIR Wizard Integration SDK'
 copyright = '2024, Codevence Solutions'
 author = 'Codevence Solutions'
-release = '1.1.0'
+release = '1.1.1'
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = 'fair-wizard-integration-sdk'
-version = '1.1.0'
+version = '1.1.1'
 description = 'Python SDK for building integrations with FAIR Wizard'
 readme = 'README.md'
 keywords = ['fair-wizard', 'integration', 'automation', 'sdk']


### PR DESCRIPTION
Bump version to 1.1.1 and add changelog entry for the Lambda layer pydantic version pinning fix.